### PR TITLE
feat: 🎸 dist/ は自動的に作られるので最初から作って .keep すると余計な差分が出るので削除した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ lerna-debug.log*
 
 node_modules
 dist/*
-!dist/.keep
 dist-ssr
 *.local
 


### PR DESCRIPTION
`$ npx vite build` のときに自動で作られ、また中身は一旦全部空っぽになるので `.keep` は差分として出てしまう